### PR TITLE
Fix Dialyzer errors

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -1,3 +1,3 @@
 [
-  {"", :unknown_type, 0} # GRPC 0.3 doesn't typecheck
+  {"lib/grpc/credential.ex", :unknown_type, 12} # GRPC 0.3 doesn't typecheck
 ]

--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -1,0 +1,3 @@
+[
+  {"", :unknown_type, 0} # GRPC 0.3 doesn't typecheck
+]

--- a/lib/pubsub/client.ex
+++ b/lib/pubsub/client.ex
@@ -71,7 +71,7 @@ defmodule Google.Pubsub.Client do
     |> send_request(&Subscriber.Stub.acknowledge/3)
   end
 
-  @spec send_request(function(), Keyword.t()) :: {:ok, any()} | {:error, any()}
+  @spec stub(function(), Keyword.t()) :: {:ok, any()} | {:error, any()}
   defp stub(fun, opts) do
     {timeout, opts} = Keyword.pop(opts, :conn_timeout, 10_000)
 

--- a/mix.exs
+++ b/mix.exs
@@ -11,7 +11,10 @@ defmodule Google.Pubsub.MixProject do
       source_url: "https://github.com/jwalton9/google_grpc_pubsub",
       description: "Elixir Library for interacting with Google Pubsub over GRPC",
       docs: docs(),
-      package: package()
+      package: package(),
+      dialyzer: [
+        plt_add_apps: [:ex_unit]
+      ]
     ]
   end
 


### PR DESCRIPTION
Just a mislabelled `@spec` and missing exunit, though GRPC doesn't typecheck so I added an ignore for it