### PR TITLE
feat: add better testing utilities

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -2,33 +2,34 @@ name: Elixir CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 permissions:
   contents: read
 
 jobs:
   build:
-
     name: Build and test
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Elixir
-      uses: erlef/setup-beam@988e02bfe678367a02564f65ca2e37726dc0268f
-      with:
-        elixir-version: '1.12.3' # Define the elixir version [required]
-        otp-version: '24.1' # Define the OTP version [required]
-    - name: Restore dependencies cache
-      uses: actions/cache@v3
-      with:
-        path: deps
-        key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
-        restore-keys: ${{ runner.os }}-mix-
-    - name: Install dependencies
-      run: mix deps.get
-    - name: Run tests
-      run: mix test
+      - uses: actions/checkout@v3
+      - name: Set up Elixir
+        uses: erlef/setup-beam@988e02bfe678367a02564f65ca2e37726dc0268f
+        with:
+          elixir-version: "1.12.3" # Define the elixir version [required]
+          otp-version: "24.1" # Define the OTP version [required]
+      - name: Restore dependencies cache
+        uses: actions/cache@v3
+        with:
+          path: deps
+          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          restore-keys: ${{ runner.os }}-mix-
+      - name: Install dependencies
+        run: mix deps.get
+      - name: Run dialyzer
+        run: mix dialyzer
+      - name: Run tests
+        run: mix test

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -24,7 +24,9 @@ jobs:
       - name: Restore dependencies cache
         uses: actions/cache@v3
         with:
-          path: deps
+          path: |
+            deps
+            _build
           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
           restore-keys: ${{ runner.os }}-mix-
       - name: Install dependencies

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -19,8 +19,8 @@ jobs:
       - name: Set up Elixir
         uses: erlef/setup-beam@988e02bfe678367a02564f65ca2e37726dc0268f
         with:
-          elixir-version: "1.12.3" # Define the elixir version [required]
-          otp-version: "24.1" # Define the OTP version [required]
+          elixir-version: "1.13.4" # Define the elixir version [required]
+          otp-version: "25.0" # Define the OTP version [required]
       - name: Restore dependencies cache
         uses: actions/cache@v3
         with:

--- a/lib/pubsub/testing.ex
+++ b/lib/pubsub/testing.ex
@@ -1,12 +1,7 @@
 defmodule Google.Pubsub.Testing do
   import ExUnit.Assertions
   alias Google.Pubsub.{Message, Testing}
-
-  defmacro __using__(_) do
-    quote do
-      import Google.Pubsub.Testing
-    end
-  end
+  alias Google.Pubsub.V1.PubsubMessage
 
   def publish(subscription_id, messages) do
     send(self(), {:messages_published, subscription_id, messages})
@@ -25,9 +20,24 @@ defmodule Google.Pubsub.Testing do
     assert_receive({:topic_created, ^topic_id})
   end
 
-  defmacro assert_messages_published(topic_id, messages) do
+  defmacro assert_messages_published(topic_id, messages, timeout \\ nil) do
     quote do
-      assert_receive({:messages_published, unquote(topic_id), unquote(messages)})
+      assert_receive(
+        {:messages_published, unquote(topic_id), messages},
+        unquote(timeout),
+        "Expected messages to be published, but none were"
+      )
+
+      published_messages =
+        messages
+        |> Enum.map(fn %PubsubMessage{data: data} ->
+          case Poison.decode(data) do
+            {:ok, data} -> data
+            _ -> data
+          end
+        end)
+
+      assert match?(published_messages, unquote(messages))
     end
   end
 

--- a/lib/pubsub/testing.ex
+++ b/lib/pubsub/testing.ex
@@ -23,21 +23,18 @@ defmodule Google.Pubsub.Testing do
   defmacro assert_messages_published(topic_id, messages, timeout \\ nil) do
     quote do
       assert_receive(
-        {:messages_published, unquote(topic_id), messages},
+        {:messages_published, unquote(topic_id), published_messages},
         unquote(timeout),
         "Expected messages to be published, but none were"
       )
 
       published_messages =
-        messages
-        |> Enum.map(fn %PubsubMessage{data: data} ->
-          case Poison.decode(data) do
-            {:ok, data} -> data
-            _ -> data
-          end
+        published_messages
+        |> Enum.map(fn %PubsubMessage{data: data, attributes: attributes} ->
+          Message.new!(data, attributes)
         end)
 
-      assert match?(published_messages, unquote(messages))
+      assert match?(unquote(messages), published_messages)
     end
   end
 

--- a/lib/pubsub/topic.ex
+++ b/lib/pubsub/topic.ex
@@ -33,8 +33,8 @@ defmodule Google.Pubsub.Topic do
   def publish(topic, messages) when is_list(messages) do
     messages =
       messages
-      |> Enum.map(fn %Message{data: data} when is_binary(data) ->
-        PubsubMessage.new(data: data)
+      |> Enum.map(fn %Message{data: data, attributes: attributes} when is_binary(data) ->
+        PubsubMessage.new(data: data, attributes: attributes)
       end)
 
     case client().publish(topic.name, messages) do

--- a/test/pubsub/subscriber_test.exs
+++ b/test/pubsub/subscriber_test.exs
@@ -11,7 +11,7 @@ end
 
 defmodule Google.Pubsub.SubscriberTest do
   use ExUnit.Case
-  use Google.Pubsub.Testing
+  import Google.Pubsub.Testing
 
   alias Google.Pubsub.Message
 

--- a/test/pubsub/subscription_test.exs
+++ b/test/pubsub/subscription_test.exs
@@ -1,6 +1,6 @@
 defmodule Google.Pubsub.SubscriptionTest do
   use ExUnit.Case
-  use Google.Pubsub.Testing
+  import Google.Pubsub.Testing
 
   alias Google.Pubsub.{Subscription, Message}
   alias Google.Pubsub.V1.{PubsubMessage}

--- a/test/pubsub/topic_test.exs
+++ b/test/pubsub/topic_test.exs
@@ -39,28 +39,41 @@ defmodule Google.Pubsub.TopicTest do
 
   describe "publish/2" do
     test "publishes single message" do
+      message = Message.new!("Hello world")
+
       assert Topic.publish(
                %Google.Pubsub.V1.Topic{name: "projects/test/topics/topic"},
-               Message.new!("Hello world")
+               message
              ) == :ok
 
       assert_messages_published("projects/test/topics/topic", [
-        "Hello world"
+        ^message
       ])
     end
 
     test "publishes multiple messages" do
-      assert Topic.publish(%Google.Pubsub.V1.Topic{name: "projects/test/topics/topic"}, [
-               Message.new!(%{hello: "world"}),
-               Message.new!("Hello world 2"),
-               Message.new!("Hello world 3")
-             ]) == :ok
+      messages = [
+        Message.new!(%{hello: "world"}),
+        Message.new!("Hello world 2"),
+        Message.new!("Hello world 3")
+      ]
 
-      assert_messages_published("projects/test/topics/topic", [
-        %{"hello" => "world"},
-        "Hello world 2",
-        "Hello world 3"
-      ])
+      assert Topic.publish(%Google.Pubsub.V1.Topic{name: "projects/test/topics/topic"}, messages) ==
+               :ok
+
+      assert_messages_published("projects/test/topics/topic", ^messages)
+    end
+
+    test "publishes messages with attributes" do
+      messages = [
+        Message.new!(%{hello: "world"}, %{type: "foo"}),
+        Message.new!(%{hello: "world"}, %{type: "bar"})
+      ]
+
+      assert Topic.publish(%Google.Pubsub.V1.Topic{name: "projects/test/topics/topic"}, messages) ==
+               :ok
+
+      assert_messages_published("projects/test/topics/topic", ^messages)
     end
   end
 end

--- a/test/pubsub/topic_test.exs
+++ b/test/pubsub/topic_test.exs
@@ -1,9 +1,8 @@
 defmodule Google.Pubsub.TopicTest do
   use ExUnit.Case
-  use Google.Pubsub.Testing
+  import Google.Pubsub.Testing
 
   alias Google.Pubsub.{Topic, Message}
-  alias Google.Pubsub.V1.PubsubMessage
 
   describe "create/1" do
     test "should create a topic project and topic provided" do
@@ -40,26 +39,27 @@ defmodule Google.Pubsub.TopicTest do
 
   describe "publish/2" do
     test "publishes single message" do
-      assert Topic.publish(%Google.Pubsub.V1.Topic{name: "projects/test/topics/topic"}, %Message{
-               data: "Hello world"
-             }) == :ok
+      assert Topic.publish(
+               %Google.Pubsub.V1.Topic{name: "projects/test/topics/topic"},
+               Message.new!("Hello world")
+             ) == :ok
 
       assert_messages_published("projects/test/topics/topic", [
-        %PubsubMessage{data: "Hello world"}
+        "Hello world"
       ])
     end
 
     test "publishes multiple messages" do
       assert Topic.publish(%Google.Pubsub.V1.Topic{name: "projects/test/topics/topic"}, [
-               %Message{data: "Hello world"},
-               %Message{data: "Hello world 2"},
-               %Message{data: "Hello world 3"}
+               Message.new!(%{hello: "world"}),
+               Message.new!("Hello world 2"),
+               Message.new!("Hello world 3")
              ]) == :ok
 
       assert_messages_published("projects/test/topics/topic", [
-        %PubsubMessage{data: "Hello world"},
-        %PubsubMessage{data: "Hello world 2"},
-        %PubsubMessage{data: "Hello world 3"}
+        %{"hello" => "world"},
+        "Hello world 2",
+        "Hello world 3"
       ])
     end
   end


### PR DESCRIPTION
This PR aims to improve the testing utilities, by allowing assertions against maps rather than the underlying `PubsubMessage` structs, when asserting messages were published