### PR TITLE
feat: Add message publish time in seconds

### DIFF
--- a/lib/proto/google/pubsub/v1/pubsub.pb.ex
+++ b/lib/proto/google/pubsub/v1/pubsub.pb.ex
@@ -327,7 +327,6 @@ defmodule Google.Pubsub.V1.ReceivedMessage do
   field(:ack_id, 1, type: :string, json_name: "ackId")
   field(:message, 2, type: Google.Pubsub.V1.PubsubMessage)
   field(:delivery_attempt, 3, type: :int32, json_name: "deliveryAttempt")
-  field(:publish_time, 4, type: Google.Protobuf.Timestamp, json_name: "publishTime")
 end
 
 defmodule Google.Pubsub.V1.GetSubscriptionRequest do

--- a/lib/proto/google/pubsub/v1/pubsub.pb.ex
+++ b/lib/proto/google/pubsub/v1/pubsub.pb.ex
@@ -327,6 +327,7 @@ defmodule Google.Pubsub.V1.ReceivedMessage do
   field(:ack_id, 1, type: :string, json_name: "ackId")
   field(:message, 2, type: Google.Pubsub.V1.PubsubMessage)
   field(:delivery_attempt, 3, type: :int32, json_name: "deliveryAttempt")
+  field(:publish_time, 4, type: Google.Protobuf.Timestamp, json_name: "publishTime")
 end
 
 defmodule Google.Pubsub.V1.GetSubscriptionRequest do

--- a/lib/pubsub/message.ex
+++ b/lib/pubsub/message.ex
@@ -5,22 +5,25 @@ defmodule Google.Pubsub.Message do
           ack_id: String.t() | nil,
           data: String.t(),
           attributes: map(),
-          delivery_attempt: number()
+          delivery_attempt: number(),
+          publish_time: number()
         }
 
-  defstruct ack_id: nil, data: nil, attributes: %{}, delivery_attempt: 0
+  defstruct ack_id: nil, data: nil, attributes: %{}, delivery_attempt: 0, publish_time: 0
 
   @spec new!(ReceivedMessage.t() | String.t() | map()) :: t()
   def new!(%ReceivedMessage{
         ack_id: ack_id,
         message: %PubsubMessage{data: data, attributes: attributes},
-        delivery_attempt: delivery_attempt
+        delivery_attempt: delivery_attempt,
+        publish_time: %Google.Protobuf.Timestamp{seconds: publish_time}
       }) do
     %__MODULE__{
       ack_id: ack_id,
       data: data,
       delivery_attempt: delivery_attempt,
-      attributes: attributes
+      attributes: attributes,
+      publish_time: publish_time
     }
   end
 

--- a/lib/pubsub/message.ex
+++ b/lib/pubsub/message.ex
@@ -14,9 +14,12 @@ defmodule Google.Pubsub.Message do
   @spec new!(ReceivedMessage.t() | String.t() | map()) :: t()
   def new!(%ReceivedMessage{
         ack_id: ack_id,
-        message: %PubsubMessage{data: data, attributes: attributes},
-        delivery_attempt: delivery_attempt,
-        publish_time: %Google.Protobuf.Timestamp{seconds: publish_time}
+        message: %PubsubMessage{
+          data: data,
+          attributes: attributes,
+          publish_time: %Google.Protobuf.Timestamp{seconds: publish_time}
+        },
+        delivery_attempt: delivery_attempt
       }) do
     %__MODULE__{
       ack_id: ack_id,

--- a/lib/pubsub/message.ex
+++ b/lib/pubsub/message.ex
@@ -6,10 +6,10 @@ defmodule Google.Pubsub.Message do
           data: String.t(),
           attributes: map(),
           delivery_attempt: number(),
-          publish_time: number()
+          publish_time: DateTime.t() | nil
         }
 
-  defstruct ack_id: nil, data: nil, attributes: %{}, delivery_attempt: 0, publish_time: 0
+  defstruct ack_id: nil, data: nil, attributes: %{}, delivery_attempt: 0, publish_time: nil
 
   @spec new!(ReceivedMessage.t() | String.t() | map()) :: t()
   def new!(%ReceivedMessage{
@@ -26,7 +26,7 @@ defmodule Google.Pubsub.Message do
       data: data,
       delivery_attempt: delivery_attempt,
       attributes: attributes,
-      publish_time: publish_time
+      publish_time: DateTime.from_unix!(publish_time)
     }
   end
 

--- a/lib/pubsub/testing/client.ex
+++ b/lib/pubsub/testing/client.ex
@@ -54,11 +54,16 @@ defmodule Google.Pubsub.Testing.Client do
                        ack_id: ack_id,
                        data: data,
                        attributes: attributes,
-                       delivery_attempt: delivery_attempt
+                       delivery_attempt: delivery_attempt,
+                       publish_time: publish_time
                      } ->
         ReceivedMessage.new(
           ack_id: ack_id || to_string(:rand.uniform()),
           delivery_attempt: delivery_attempt,
+          publish_time: %Google.Protobuf.Timestamp{
+            seconds: publish_time,
+            nanos: 0
+          },
           message: %PubsubMessage{
             data: data,
             attributes: attributes

--- a/lib/pubsub/testing/client.ex
+++ b/lib/pubsub/testing/client.ex
@@ -61,7 +61,7 @@ defmodule Google.Pubsub.Testing.Client do
           ack_id: ack_id || to_string(:rand.uniform()),
           delivery_attempt: delivery_attempt,
           publish_time: %Google.Protobuf.Timestamp{
-            seconds: publish_time,
+            seconds: DateTime.to_unix(publish_time),
             nanos: 0
           },
           message: %PubsubMessage{

--- a/lib/pubsub/testing/client.ex
+++ b/lib/pubsub/testing/client.ex
@@ -60,13 +60,13 @@ defmodule Google.Pubsub.Testing.Client do
         ReceivedMessage.new(
           ack_id: ack_id || to_string(:rand.uniform()),
           delivery_attempt: delivery_attempt,
-          publish_time: %Google.Protobuf.Timestamp{
-            seconds: DateTime.to_unix(publish_time),
-            nanos: 0
-          },
           message: %PubsubMessage{
             data: data,
-            attributes: attributes
+            attributes: attributes,
+            publish_time: %Google.Protobuf.Timestamp{
+              seconds: DateTime.to_unix(publish_time),
+              nanos: 0
+            }
           }
         )
       end)

--- a/lib/pubsub/testing/client.ex
+++ b/lib/pubsub/testing/client.ex
@@ -57,6 +57,8 @@ defmodule Google.Pubsub.Testing.Client do
                        delivery_attempt: delivery_attempt,
                        publish_time: publish_time
                      } ->
+        IO.inspect(publish_time, label: "HSASJFOIASF")
+
         ReceivedMessage.new(
           ack_id: ack_id || to_string(:rand.uniform()),
           delivery_attempt: delivery_attempt,
@@ -64,7 +66,7 @@ defmodule Google.Pubsub.Testing.Client do
             data: data,
             attributes: attributes,
             publish_time: %Google.Protobuf.Timestamp{
-              seconds: DateTime.to_unix(publish_time),
+              seconds: if(publish_time, do: DateTime.to_unix(publish_time), else: 0),
               nanos: 0
             }
           }

--- a/lib/pubsub/testing/client.ex
+++ b/lib/pubsub/testing/client.ex
@@ -57,8 +57,6 @@ defmodule Google.Pubsub.Testing.Client do
                        delivery_attempt: delivery_attempt,
                        publish_time: publish_time
                      } ->
-        IO.inspect(publish_time, label: "HSASJFOIASF")
-
         ReceivedMessage.new(
           ack_id: ack_id || to_string(:rand.uniform()),
           delivery_attempt: delivery_attempt,

--- a/lib/pubsub/testing/client.ex
+++ b/lib/pubsub/testing/client.ex
@@ -64,7 +64,8 @@ defmodule Google.Pubsub.Testing.Client do
             data: data,
             attributes: attributes,
             publish_time: %Google.Protobuf.Timestamp{
-              seconds: if(publish_time, do: DateTime.to_unix(publish_time), else: 0),
+              seconds:
+                if(publish_time, do: publish_time, else: DateTime.utc_now()) |> DateTime.to_unix(),
               nanos: 0
             }
           }


### PR DESCRIPTION
This adds publish time into the message struct. According to the docs, the Google.Protobuf.Timestamp struct has a seconds and nanos field. seconds being the number of utc seconds since unix epoch, and nanos being fractions of a second at nanosecond resolution. I think we probably won't need millisecond level precision, hence I decided to not use nanos field

https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#timestamp